### PR TITLE
게시판 페이징, 정렬 구현

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleCommentController.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleCommentController.java
@@ -1,9 +1,16 @@
 package com.fastcampus.projectboard.controller;
 
+import com.fastcampus.projectboard.domain.ArticleComment;
+import com.fastcampus.projectboard.dto.ArticleCommentDto;
+import com.fastcampus.projectboard.dto.response.ArticleCommentResponse;
 import com.fastcampus.projectboard.service.ArticleCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/articleComment")
@@ -11,5 +18,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ArticleCommentController {
     private final ArticleCommentService articleCommentService;
 
+    @PostMapping("/new")
+    public void saveComment(@PathVariable Long articleId){
+        /**
+         * 1. 게시물 id가져와야함
+         * 2. 입력 값 가져와야함
+         */
 
+    }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -9,6 +9,7 @@ import com.fastcampus.projectboard.dto.response.ArticleCommentResponse;
 import com.fastcampus.projectboard.dto.response.ArticleResponse;
 import com.fastcampus.projectboard.repository.ArticleRepository;
 import com.fastcampus.projectboard.service.ArticleService;
+import com.fastcampus.projectboard.service.PaginationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -27,13 +28,19 @@ import java.util.List;
 public class ArticleController {
     private final ArticleService articleService;
 
+    private final PaginationService paginationService;
     @GetMapping
     public String articles(@RequestParam(required = false) SearchType searchType,
                            @RequestParam(required = false) String searchValue,
                            @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable,
                            ModelMap map
                            ){
-        map.addAttribute("articles", articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from));
+        Page<ArticleResponse> article = articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), article.getTotalPages());
+
+        map.addAttribute("articles", article);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+
         return "articles/index";
     }
 

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -1,17 +1,12 @@
 package com.fastcampus.projectboard.controller;
 
-import com.fastcampus.projectboard.domain.Article;
 import com.fastcampus.projectboard.domain.type.SearchType;
-import com.fastcampus.projectboard.dto.ArticleCommentDto;
 import com.fastcampus.projectboard.dto.ArticleDto;
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
-import com.fastcampus.projectboard.dto.response.ArticleCommentResponse;
 import com.fastcampus.projectboard.dto.response.ArticleResponse;
-import com.fastcampus.projectboard.repository.ArticleRepository;
 import com.fastcampus.projectboard.service.ArticleService;
 import com.fastcampus.projectboard.service.PaginationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -51,6 +46,8 @@ public class ArticleController {
 
         map.addAttribute("article", articleWithCommentsDto);
         map.addAttribute("articleComments", articleWithCommentsDto.articleCommentDtos());
+
+
         return "articles/detail";
     }
 

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/type/SearchType.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/type/SearchType.java
@@ -1,5 +1,17 @@
 package com.fastcampus.projectboard.domain.type;
 
+import lombok.Getter;
+
 public enum SearchType {
-    TITLE, CONTENT, ID, NICKNAME, HASHTAG
+    TITLE("제목"),
+    CONTENT("본문"),
+    ID("유저 ID"),
+    NICKNAME("닉네임"),
+    HASHTAG("해시태그");
+
+    @Getter private final String description;
+
+    SearchType(String description){
+        this.description = description;
+    }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentResponse.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentResponse.java
@@ -17,7 +17,7 @@ public record ArticleWithCommentResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentResponses
-) implements Serializable {
+) {
 
     public static ArticleWithCommentResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleCommentService.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleCommentService.java
@@ -14,15 +14,20 @@ import java.util.List;
 @Service
 public class ArticleCommentService {
 
-    private final ArticleRepository articleRepository;
     private final ArticleCommentRepository articleCommentRepository;
 
     @Transactional(readOnly = true)
     public List<ArticleCommentDto> searchArticleComments(Long articleId) {
-        return List.of();
+        return articleCommentRepository.findByArticle_Id(articleId)
+                .stream()
+                .map(ArticleCommentDto::from)
+                .toList();
     }
 
     public void saveArticleComment(ArticleCommentDto dto) {
+        /**
+         * 1. controller에서 가져온 정보(dto)를 저장
+         */
     }
 
     public void updateArticleComment(ArticleCommentDto dto) {

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/PaginationService.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/PaginationService.java
@@ -1,0 +1,25 @@
+package com.fastcampus.projectboard.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+public class PaginationService {
+    private static final int BAR_LENGTH = 5;
+
+    //1~5, 6~10 이런 식으로 5개의 페이지 씩 나눠지도록 구현
+    public List<Integer> getPaginationBarNumbers(int currentPageNumber, int  totalPages) {
+        int startNumber = currentPageNumber >= BAR_LENGTH ? (BAR_LENGTH * (currentPageNumber / BAR_LENGTH)) : 0;
+        int endNumber = startNumber + Math.min(BAR_LENGTH, totalPages);
+
+        return IntStream.range(startNumber, endNumber).boxed().toList();
+    }
+
+    public int currentBarLength() {
+        return BAR_LENGTH;
+    }
+}
+
+//(5 * (articles.number / 5))+4 > articles.totalPages-1 ? articles.totalPages-1 : (5 * (articles.number / 5))+4)}

--- a/fastcampus-project-board/src/main/resources/templates/articles/detail.html
+++ b/fastcampus-project-board/src/main/resources/templates/articles/detail.html
@@ -60,7 +60,7 @@
 
     <nav aria-label="Page navigation example">
         <ul class="pagination">
-            <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+            <li class="page-item"><a class="page-link" th:href="@{'/articles/' + ${article.id}}">Previous</a></li>
             <li class="page-item"><a class="page-link" href="#">Next</a></li>
         </ul>
     </nav>

--- a/fastcampus-project-board/src/main/resources/templates/articles/index.html
+++ b/fastcampus-project-board/src/main/resources/templates/articles/index.html
@@ -52,10 +52,10 @@
         <table id="article-table" class="table">
             <thead>
                 <tr>
-                    <th class="col-6">제목</th>
-                    <th class="col">해시태그</th>
-                    <th class="col">작성자</th>
-                    <th class="col">작성일</th>
+                    <th class="title col-6"><a onclick="sortTable(0)">제목</a></th>
+                    <th class="hashtag col"><a onclick="sortTable(1)">해시태그</a></th>
+                    <th class="create-user col"><a onclick="sortTable(2)">작성자</a></th>
+                    <th class="create-date col"><a onclick="sortTable(3)">작성일</a></th>
                 </tr>
             </thead>
             <tbody>
@@ -73,5 +73,33 @@
         <footer id="footer"></footer>
     </main>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
+    <script>
+        function sortTable(columnIndex) {
+            var table, rows, switching, i, x, y, shouldSwitch;
+            table = document.getElementById("article-table");
+            switching = true;
+
+            while (switching) {
+                switching = false;
+                rows = table.rows;
+
+                for (i = 1; i < (rows.length - 1); i++) {
+                    shouldSwitch = false;
+                    x = rows[i].getElementsByTagName("TD")[columnIndex];
+                    y = rows[i + 1].getElementsByTagName("TD")[columnIndex];
+
+                    if (x.innerText.toLowerCase() > y.innerText.toLowerCase()) {
+                        shouldSwitch = true;
+                        break;
+                    }
+                }
+
+                if (shouldSwitch) {
+                    rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+                    switching = true;
+                }
+            }
+        }
+    </script>
 </body>
 </html>

--- a/fastcampus-project-board/src/main/resources/templates/articles/index.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/articles/index.th.xml
@@ -10,6 +10,27 @@
     <attr sel="nav" th:replace="navigator::nav"/>
 
     <attr sel="#article-table">
+<!--        <attr sel="thead">-->
+<!--            <attr sel="tr">-->
+<!--                <attr sel="th.title/a" th:href="@{/articles(-->
+<!--                page=${articles.number},-->
+<!--                sort='title' + (*{articles.sort.getOrderFor('title')} != null ? (*{articles.sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : '')-->
+<!--                )}"/>-->
+<!--                <attr sel="th.hashtag/a" th:href="@{/articles(-->
+<!--                page=${articles.number},-->
+<!--                sort='hashtag' + (*{articles.sort.getOrderFor('hashtag')} != null ? (*{articles.sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : '')-->
+<!--                )}"/>-->
+<!--                <attr sel="th.create-user/a" th:href="@{/articles(-->
+<!--                page=${articles.number},-->
+<!--                sort='createUser' + (*{articles.sort.getOrderFor('createUser')} != null ? (*{articles.sort.getOrderFor('createUser').direction.name} != 'DESC' ? ',desc' : '') : '')-->
+<!--                )}"/>-->
+<!--                <attr sel="th.create-date/a" th:href="@{/articles(-->
+<!--                page=${articles.number},-->
+<!--                sort='createDate' + (*{articles.sort.getOrderFor('createDate')} != null ? (*{articles.sort.getOrderFor('createDate').direction.name} != 'DESC' ? ',desc' : '') : '')-->
+<!--                )}"/>-->
+<!--            </attr>-->
+<!--        </attr>-->
+
         <attr sel="tbody">
             <attr sel="tr" th:each="article : ${articles}">
                 <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}"/>

--- a/fastcampus-project-board/src/main/resources/templates/navigator.html
+++ b/fastcampus-project-board/src/main/resources/templates/navigator.html
@@ -13,8 +13,8 @@
             <li class="page-item" th:unless="${articles.first}">
                 <a class="page-link" th:href="@{'/articles'(page=${articles.number-1})}">Previous</a>
             </li>
-            <li class="page-item" th:each="item : ${#numbers.sequence(articles.number >= 5 ? (5 * (articles.number / 5)) : 0, (5 * (articles.number / 5))+4 > articles.totalPages-1 ? articles.totalPages-1 : (5 * (articles.number / 5))+4)}">
-                <a class="page-link" th:href="@{'/articles'(page=${item})}" th:text="${item + 1}">Page number</a>
+            <li class="page-item" th:each="item : ${paginationBarNumbers}">
+                <a th:class="'page-link' + (${articles.number} == ${item} ? ' disabled' : '')" th:href="@{'/articles'(page=${item})}" th:text="${item + 1}">Page number</a>
             </li>
             <li class="page-item" th:unless="${articles.last}">
                 <a class="page-link" th:href="@{'/articles'(page=${articles.number+1})}">Next</a>
@@ -22,6 +22,7 @@
             <li class="page-item" th:unless="${articles.last}">
                 <a class="page-link" th:href="@{'/articles'(page=${articles.totalPages-1})}">Last</a>
             </li>
+
         </ul>
     </nav>
 </body>


### PR DESCRIPTION
정렬은 강의에선 게시글 전체 데이터를 정렬하는 것으로 알려줬지만
나는 화면에 보이는 게시판 페이지에서만 정렬이 될 수 있도록 구현함.

이런 식으로 게시판 페이지에서만 정렬될 수 있도록 하기 위해선 스크립트에서 작업하는 수 밖에 없다고 함.