### PR TITLE
해시태그 검색 페이지와 관련 기능 구현

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -58,4 +58,22 @@ public class ArticleController {
     public void saveArticle(@RequestBody ArticleDto dto){
         articleService.saveArticle(dto);
     }
+
+    @GetMapping("/search-hashtag")
+    public String searchHashtag(
+            @RequestParam(required = false) String searchValue,
+            @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map
+    ){
+        Page<ArticleResponse> articles = articleService.searchArticlesViaHashtag(searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+        List<String> hashtags = articleService.getHashtags();
+
+        map.addAttribute("articles", articles);
+        map.addAttribute("hashtags", hashtags);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchType", SearchType.HASHTAG);
+
+        return "articles/search-hashtag";
+    }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/ArticleDto.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/ArticleDto.java
@@ -15,10 +15,28 @@ public record ArticleDto(
         LocalDateTime updateDate,
         String updateUser
 ) {
+    /**
+     * ArticleDto 객체 반환
+     * @param id
+     * @param userAccountDto
+     * @param title
+     * @param content
+     * @param hashtag
+     * @param createDate
+     * @param createUser
+     * @param updateDate
+     * @param updateUser
+     * @return
+     */
     public static ArticleDto of(Long id, UserAccountDto userAccountDto, String title, String content, String hashtag, LocalDateTime createDate, String createUser, LocalDateTime updateDate, String updateUser) {
         return new ArticleDto(id, userAccountDto, title, content, hashtag, createDate, createUser, updateDate, updateUser);
     }
 
+    /**
+     * 세팅된 ArticleDto 객체 반환
+     * @param entity
+     * @return
+     */
     public static ArticleDto from(Article entity) {
         return new ArticleDto(
                 entity.getId(),

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.Article;
 import com.fastcampus.projectboard.domain.QArticle;
+import com.fastcampus.projectboard.repository.querydsl.ArticleRepositoryCustom;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource //이 어노테이션이 있어야만 해당 엔티티에 대한 rest api를 사용할 수 있음
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
+        ArticleRepositoryCustom,
         QuerydslPredicateExecutor<Article>,     //Article 엔티티에 있는 모든 필드에 대한 기본 검색 기능 제공. 대소문자 구분하지 않고 부분 검색은 안된다.
         QuerydslBinderCustomizer<QArticle>      //위에서 안되는 부분 검색이 가능하도록 해줌
 {

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustom.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.fastcampus.projectboard.repository.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+    List<String> findAllDistinctHashtags();
+}

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,31 @@
+package com.fastcampus.projectboard.repository.querydsl;
+
+import com.fastcampus.projectboard.domain.Article;
+import com.fastcampus.projectboard.domain.QArticle;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom{
+
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    /**
+     * article 테이블에서 중복 제거한 hashtag 데이터를 조회
+     * @return List<article>  해쉬태그 속성만 가져옴
+     */
+    @Override
+    public List<String> findAllDistinctHashtags() {
+        QArticle article = QArticle.article;
+
+        return from(article)
+                .distinct()
+                //.select(article) > 이건 article 정보 다 가져오는 것이기 때문에 querydsl 쓸 필요 없음
+                .select(article.hashtag) // 하나의 컬럼만 조회하고 싶을 때 이렇게 표현함
+                .where(article.hashtag.isNotNull())
+                .fetch();
+    }
+}

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @RequiredArgsConstructor //articleRepository의 생성자를 만들고 해당 클래스에 주입시켜주는 역할
 @Slf4j
 @Transactional
@@ -71,9 +73,23 @@ public class ArticleService {
 
 
     }
-
     public void deleteArticle(long articleId) {
         articleRepository.deleteById(articleId);
     }
 
+    public long getArticleCount() {
+        return articleRepository.count();
+    }
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable){
+        if(hashtag == null || hashtag.isBlank()) {
+            return Page.empty(pageable);
+        }
+
+        return articleRepository.findByHashtag(hashtag, pageable).map(ArticleDto::from);
+    }
+
+    public List<String> getHashtags(){
+        return articleRepository.findAllDistinctHashtags();
+    }
 }

--- a/fastcampus-project-board/src/main/resources/templates/articles/search-hashtag.html
+++ b/fastcampus-project-board/src/main/resources/templates/articles/search-hashtag.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <title>해시태그 검색</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    <link href="/css/articles/table-header.css" rel="stylesheet">
+</head>
+
+<body>
+<header id="header">
+    헤더 삽입부
+    <hr>
+</header>
+
+<main class="container">
+    <header class="py-5 text-center">
+        <h1>Hashtags</h1>
+    </header>
+
+    <section class="row">
+        <div id="hashtags" class="col-9 d-flex flex-wrap justify-content-evenly">
+            <div class="p-2">
+                <h2 class="text-center lh-lg font-monospace"><a href="#">#java</a></h2>
+            </div>
+        </div>
+    </section>
+
+    <hr>
+
+    <table class="table" id="article-table">
+        <thead>
+        <tr>
+            <th class="title col-6"><a>제목</a></th>
+            <th class="content col-4"><a>본문</a></th>
+            <th class="user-id"><a>작성자</a></th>
+            <th class="created-at"><a>작성일</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td class="title"><a>첫글</a></td>
+            <td class="content"><span class="d-inline-block text-truncate" style="max-width: 300px;">본문</span></td>
+            <td class="user-id">Uno</td>
+            <td class="created-at"><time>2022-01-01</time></td>
+        </tr>
+        <tr>
+            <td>두번째글</td>
+            <td>본문</td>
+            <td>Uno</td>
+            <td><time>2022-01-02</time></td>
+        </tr>
+        <tr>
+            <td>세번째글</td>
+            <td>본문</td>
+            <td>Uno</td>
+            <td><time>2022-01-03</time></td>
+        </tr>
+        </tbody>
+    </table>
+
+    <nav id="pagination" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+            <li class="page-item"><a class="page-link" href="#">1</a></li>
+            <li class="page-item"><a class="page-link" href="#">Next</a></li>
+        </ul>
+    </nav>
+
+</main>
+
+<footer id="footer">
+    <hr>
+    푸터 삽입부
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/fastcampus-project-board/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#header" th:replace="header :: header" />
+    <attr sel="#footer" th:replace="footer :: footer" />
+
+    <attr sel="main" th:object="${articles}">
+        <attr sel="#hashtags" th:remove="all-but-first">
+            <attr sel="div" th:each="hashtag : ${hashtags}">
+                <attr sel="a" th:class="'text-reset'" th:text="${hashtag}" th:href="@{/articles/search-hashtag(
+            page=${param.page},
+            sort=${param.sort},
+            searchType=${searchType.name},
+            searchValue=${hashtag}
+        )}" />
+            </attr>
+        </attr>
+
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.content/a" th:text="'본문'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='content' + (*{sort.getOrderFor('content')} != null ? (*{sort.getOrderFor('content').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='createDate' + (*{sort.getOrderFor('createDate')} != null ? (*{sort.getOrderFor('createDate').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+            </attr>
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.content/span" th:text="${article.content}" />
+                    <attr sel="td.user-id" th:text="${article.nickname}" />
+                    <attr sel="td.created-at/time" th:datetime="${article.createDate}" th:text="${#temporals.format(article.createDate, 'yyyy-MM-dd')}" />
+                </attr>
+            </attr>
+        </attr>
+
+        <attr sel="#pagination">
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:text="'previous'"
+                      th:href="@{/articles(page=${articles.number - 1}, sort=${param.sort}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+                />
+                <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                    <attr sel="a"
+                          th:text="${pageNumber + 1}"
+                          th:href="@{/articles(page=${pageNumber}, sort=${param.sort}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                          th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                    />
+                </attr>
+                <attr sel="li[2]/a"
+                      th:text="'next'"
+                      th:href="@{/articles(page=${articles.number + 1}, sort=${param.sort}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+                />
+            </attr>
+        </attr>
+    </attr>
+</thlogic>

--- a/fastcampus-project-board/src/main/resources/templates/header.html
+++ b/fastcampus-project-board/src/main/resources/templates/header.html
@@ -12,7 +12,7 @@
                 </a>
 
                 <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                    <li><a href="#" class="nav-link px-2 text-white">Home</a></li>
+                    <li><a href="/articles" class="nav-link px-2 text-white">Home</a></li>
                 </ul>
 
                 <form class="col-12 col-lg-auto mb-3 mb-lg-0 me-lg-3" role="search">


### PR DESCRIPTION
해시태그만을 위한 화면 구현
1. 화면에 해시태그 리스트 조회
2. 해시태그 클릭 시 관련 게시글 조회 됨
3. 페이징 기능
4. 정렬 기능
5. queryDSL 사용하여 해시태그 데이터 조회