### PR TITLE
헤로쿠 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/fastcampus-project-board/src/main/resources/application.yaml
+++ b/fastcampus-project-board/src/main/resources/application.yaml
@@ -50,7 +50,7 @@ spring:
 #    activate:
 #      on-profile: heroku
 #  datasource:
-#    url: ${CLEARDB_DATABASE_URL}
+#    url: ${JAWSDB_URL}
 #    username: hg
 #    password: asdf1234
 #  jpa:


### PR DESCRIPTION
조사해본 결과, clearDB의 기본 mysql 버전이 `5,6`으로 너무 낮기 때문에 문제가 발생한 것으로 확인됨(5.6 버전에서는`article_comment.content` 인덱스 사이즈가 너무 큼)
대안으로 jawsDB를 찾아냄 
기본 mysql 버전이 `8.0`
이를 이용해 환경변수를 다시 작업