### PR TITLE
해시태그 검색 기능 고도화

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -51,6 +51,7 @@ public class ArticleController {
         map.addAttribute("articles", article);
         map.addAttribute("paginationBarNumbers", barNumbers);
         map.addAttribute("searchTypes", SearchType.values());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/index";
     }
@@ -70,6 +71,7 @@ public class ArticleController {
         map.addAttribute("articleComments", article.articleCommentResponses());
         //다음, 이전 게시물로 이동할 때 필요
         map.addAttribute("totalCount", articleService.getArticleCount());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/detail";
     }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/HashtagRepository.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/HashtagRepository.java
@@ -1,6 +1,7 @@
 package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.Hashtag;
+import com.fastcampus.projectboard.repository.querydsl.HashtagRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
@@ -12,6 +13,7 @@ import java.util.Set;
 @RepositoryRestResource
 public interface HashtagRepository extends
         JpaRepository<Hashtag, Long>,
+        HashtagRepositoryCustom,
         QuerydslPredicateExecutor<Hashtag> {
     Optional<Hashtag> findByHashtagName(String hashtagName);
     List<Hashtag> findByHashtagNameIn(Set<String> hashtagNames);

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/HashtagRepositoryCustomImpl.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/HashtagRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.fastcampus.projectboard.repository.querydsl;
 
 import com.fastcampus.projectboard.domain.Hashtag;
+import com.fastcampus.projectboard.domain.QHashtag;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
 import java.util.List;
@@ -13,6 +14,10 @@ public class HashtagRepositoryCustomImpl extends QuerydslRepositorySupport imple
 
     @Override
     public List<String> findAllHashtagNames() {
-        return null;
+        QHashtag hashtag = QHashtag.hashtag;
+
+        return from(hashtag)
+                .select(hashtag.hashtagName)
+                .fetch();
     }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
@@ -1,11 +1,13 @@
 package com.fastcampus.projectboard.service;
 
 import com.fastcampus.projectboard.domain.Article;
+import com.fastcampus.projectboard.domain.Hashtag;
 import com.fastcampus.projectboard.domain.UserAccount;
 import com.fastcampus.projectboard.domain.constant.SearchType;
 import com.fastcampus.projectboard.dto.ArticleDto;
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampus.projectboard.repository.ArticleRepository;
+import com.fastcampus.projectboard.repository.HashtagRepository;
 import com.fastcampus.projectboard.repository.UserAccountRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor //articleRepository의 생성자를 만들고 해당 클래스에 주입시켜주는 역할
 @Slf4j
@@ -26,6 +30,8 @@ public class ArticleService {
 
     private final ArticleRepository articleRepository;
     private final UserAccountRepository userAccountRepository;
+    private final HashtagService hashtagService;
+    private final HashtagRepository hashtagRepository;
 
     @Transactional(readOnly = true)
     public Page<ArticleDto> searchArticles(SearchType searchType, String searchKeyword, Pageable pageable) {
@@ -61,7 +67,11 @@ public class ArticleService {
 
     public void saveArticle(ArticleDto dto) {
         UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
-        articleRepository.save(dto.toEntity(userAccount));
+        Set<Hashtag> hashtags = renewHashtagsFromContent(dto.content());
+
+        Article article = dto.toEntity(userAccount);
+        article.addHashtags(hashtags);
+        articleRepository.save(article);
     }
 
     public void updateArticle(Long articleId, ArticleDto dto) {
@@ -78,7 +88,24 @@ public class ArticleService {
                 if(dto.title() != null) article.setTitle(dto.title());
                 if(dto.content() != null) article.setContent(dto.content());
 
-                //article.setHashtag(dto.hashtag());
+                //기존에 게시글에 등록되었던 해시태그 조회
+                Set<Long> hashtagIds = article.getHashtags().stream()
+                        .map(Hashtag::getId)
+                        .collect(Collectors.toUnmodifiableSet());
+
+                //기존에 등록된 해시태그 모두 삭제
+                article.clearHashtags();
+                //삭제 정보 바로 DB에 반영 > 등록, 수정, 삭제가 일어날 때 hashtag 테이블에 어떻게 반영이 되는지 아직 이해가 안됨 > 중간 테이블에 간접 반영
+                //위에 코드에서 clearHashtags()가 실행되면 article_hashtag 테이블에서 해당 게시글에 관련된 해시태그 정보는 사라지는 듯
+                articleRepository.flush();
+
+                //어떤 게시물에도 등록되지 않은 해시태그는 hashtag 테이블에서 데이터 삭제
+                // > 중간 테이블에서 조회 했을 때, 어떤 게시글에도 해시태그가 등록되어있지 않다면 해시태그 삭제
+                hashtagIds.forEach(hashtagService::deleteHashtagWithoutArticles);
+
+                //게시글 본문에서 파싱된 hashtag 새롭게 등록
+                Set<Hashtag> hashtags = renewHashtagsFromContent(dto.content());
+                article.addHashtags(hashtags);
             }
             /**
              * 이 함수는 클래스 레벨의 @Transactional이 선언되어 있기 때문에
@@ -91,22 +118,56 @@ public class ArticleService {
 
     }
     public void deleteArticle(long articleId, String userId) {
+        Article article = articleRepository.getReferenceById(articleId);
+        Set<Long> hashtagIds = article.getHashtags().stream()
+                .map(Hashtag::getId)
+                .collect(Collectors.toUnmodifiableSet());
+
         articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
+        articleRepository.flush();
+
+        hashtagIds.forEach(hashtagService::deleteHashtagWithoutArticles);
     }
 
     public long getArticleCount() {
         return articleRepository.count();
     }
     @Transactional(readOnly = true)
-    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
-        if (hashtag == null || hashtag.isBlank()) {
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtagName, Pageable pageable) {
+        if (hashtagName == null || hashtagName.isBlank()) {
             return Page.empty(pageable);
         }
 
-        return articleRepository.findByHashtagNames(null, pageable).map(ArticleDto::from);
+        return articleRepository.findByHashtagNames(List.of(hashtagName), pageable)
+                .map(ArticleDto::from);
     }
 
     public List<String> getHashtags() {
-        return articleRepository.findAllDistinctHashtags();
+        return hashtagRepository.findAllHashtagNames(); // TODO: HashtagService 로 이동을 고려해보자.
+    }
+
+    /**
+     * 게시글 본문에서 hashtag 추출
+     * @param content
+     * @return
+     */
+    private Set<Hashtag> renewHashtagsFromContent(String content) {
+        // 게시글 본문에서 파싱된 해시태그
+        Set<String> hashtagNamesInContent = hashtagService.parseHashtagNames(content);
+        // HashtagName으로 DB에서 조회
+        Set<Hashtag> hashtags = hashtagService.findHashtagsByNames(hashtagNamesInContent);
+        // 실제로 DB에 등록되어 있는 Hashtag는 조회가되어 existingHashtagNames에 담김
+        Set<String> existingHashtagNames = hashtags.stream()
+                .map(Hashtag::getHashtagName)
+                .collect(Collectors.toUnmodifiableSet());
+
+        //DB에서 조회되지 않은 해시태그들은 추가로 hashtags에 넣어서 새로 등록될 수 있도록 하기
+        hashtagNamesInContent.forEach(newHashtagName -> {
+            if (!existingHashtagNames.contains(newHashtagName)) {
+                hashtags.add(Hashtag.of(newHashtagName));
+            }
+        });
+
+        return hashtags;
     }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/HashtagService.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/HashtagService.java
@@ -1,11 +1,16 @@
 package com.fastcampus.projectboard.service;
 
+import com.fastcampus.projectboard.domain.Hashtag;
+import com.fastcampus.projectboard.repository.HashtagRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 @RequiredArgsConstructor
@@ -13,14 +18,38 @@ import java.util.Set;
 @Transactional
 @Service
 public class HashtagService {
-    public Object parseHashtagNames(String content) {
-        return null;
+    private final HashtagRepository hashtagRepository;
+
+    @Transactional(readOnly = true)
+    public Set<Hashtag> findHashtagsByNames(Set<String> hashtagNames) {
+        return new HashSet<>(hashtagRepository.findByHashtagNameIn(hashtagNames));
     }
 
-    public Object findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
+    public Set<String> parseHashtagNames(String content) {
+        if (content == null) {
+            return Set.of(); // 비어있는 Set 리턴
+        }
+
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");    //해시태그 정규식 검사
+        Matcher matcher = pattern.matcher(content.strip());   //앞 뒤 공백 제거
+        Set<String> result = new HashSet<>();
+
+        while (matcher.find()) {
+            result.add(matcher.group().replace("#", ""));
+        }
+
+        return Set.copyOf(result); // 수정 불가능한 Set을 리턴. 내부적으로 copy가 일어나는 듯
     }
 
-    public void deleteHashtagWithoutArticles(Object any) {
+    public void deleteHashtagWithoutArticles(Long hashtagId) {
+        Hashtag hashtag = hashtagRepository.getReferenceById(hashtagId);
+        /**
+         * 1. ID로 해시태그 가져옴
+         * 2. 해당 해시태그를 갖고 있는 게시글 리스트 가져옴.
+         * 3. 비었다면 > 해당 해시태그를 갖고 있는 게시글이 없다면 삭제
+         */
+        if (hashtag.getArticles().isEmpty()) {
+            hashtagRepository.delete(hashtag);
+        }
     }
 }

--- a/fastcampus-project-board/src/main/resources/templates/articles/detail.html
+++ b/fastcampus-project-board/src/main/resources/templates/articles/detail.html
@@ -24,11 +24,11 @@
                 <p>
                     <time id="createDate" datetime="2023-08-21T00:00:00"></time>
                 </p>
-                <p id="hashtag">#java</p>
+                <p><span id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></p>
             </aside>
         </section>
 
-        <article id="content" class="col-md-9 col-lg-8">
+        <article id="article-content" class="col-md-9 col-lg-8">
             <pre>본문</pre>
         </article>
     </div>

--- a/fastcampus-project-board/src/main/resources/templates/articles/detail.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/articles/detail.th.xml
@@ -2,10 +2,10 @@
 <thlogic>
     <!--  해당 파일명이 index.th.xml이라서 파일명이 index인 파일을 찾아서 header라는 엘리먼트를 찾아서 이 코드를 삽입해줌  -->
     <!--  만약 header라는 엘리먼트가 많을 경우 id로 설정해서 #id명으로 설정해서 id를 맵핑하게끔 구현하면 됨  -->
-    <attr sel="#header" th:replace="header :: header"/>
+    <attr sel="#header" th:replace="~{header :: header}"/>
 
     <!--root경로에 있는 footer 파일에서 footer 엘리먼트를 찾아가라는 의미. 그 엘리먼트 내용으로 replace 한다는 말-->
-    <attr sel="#footer" th:replace="footer :: footer" />
+    <attr sel="#footer" th:replace="~{footer :: footer}"/>
 
     <attr sel="#nickname" th:text="${article.nickname}"/>
 
@@ -15,9 +15,14 @@
 
     <attr sel="#createDate" th:text="${article.createDate}"/>
 
-    <attr sel="#hashtag" th:text="${article.hashtags}"/>
+    <attr sel="#hashtag" th:each="hashtag : ${article.hashtags}">
+        <attr sel="a"
+              th:text="'#' + ${hashtag}"
+              th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+        />
+    </attr>
 
-    <attr sel="#content" th:text="${article.content}"/>
+    <attr sel="#article-content/pre" th:text="${article.content}" />
 
     <attr sel="#article-comments">
         <attr sel="li" th:each="articleComment : ${articleComments}">

--- a/fastcampus-project-board/src/main/resources/templates/articles/form.html
+++ b/fastcampus-project-board/src/main/resources/templates/articles/form.html
@@ -35,12 +35,7 @@
                 <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
             </div>
         </div>
-        <div class="row mb-4 justify-content-md-center">
-            <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
-            <div class="col-sm-8 col-lg-9">
-                <input type="text" class="form-control" id="hashtag" name="hashtag">
-            </div>
-        </div>
+
         <div class="row mb-5 justify-content-md-center">
             <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
                 <button type="submit" class="btn btn-primary" id="submit-button">저장</button>

--- a/fastcampus-project-board/src/main/resources/templates/articles/form.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/articles/form.th.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#header" th:replace="header :: header" />
-    <attr sel="#footer" th:replace="footer :: footer" />
+    <attr sel="#header" th:replace="~{header :: header}"/>
+    <attr sel="#footer" th:replace="~{footer :: footer}"/>
 
     <attr sel="#article-form-header/h1" th:text="${formStatus} ? '게시글 ' + ${formStatus.description} : _" />
 
     <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
         <attr sel="#title" th:value="${article?.title} ?: _" />
         <attr sel="#content" th:text="${article?.content} ?: _" />
-        <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
         <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
         <attr sel="#cancel-button" th:onclick="'history.back()'" />
     </attr>

--- a/fastcampus-project-board/src/main/resources/templates/articles/index.html
+++ b/fastcampus-project-board/src/main/resources/templates/articles/index.html
@@ -62,7 +62,7 @@
                 <tbody>
                     <tr>
                         <td class="title"><a></a></td>
-                        <td class="hashtag"></td>
+                        <td class="hashtag"><span class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></td>
                         <td class="user-id"></td>
                         <td class="createDate"><time></time></td>
                     </tr>

--- a/fastcampus-project-board/src/main/resources/templates/articles/index.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/articles/index.th.xml
@@ -2,12 +2,12 @@
 <thlogic>
     <!--  해당 파일명이 index.th.xml이라서 파일명이 index인 파일을 찾아서 header라는 엘리먼트를 찾아서 이 코드를 삽입해줌  -->
     <!--  만약 header라는 엘리먼트가 많을 경우 id로 설정해서 #id명으로 설정해서 id를 맵핑하게끔 구현하면 됨  -->
-    <attr sel="#header" th:replace="header :: header"/>
+    <attr sel="#header" th:replace="~{header :: header}"/>
 
     <!--root경로에 있는 footer 파일에서 footer 엘리먼트를 찾아가라는 의미. 그 엘리먼트 내용으로 replace 한다는 말-->
-    <attr sel="#footer" th:replace="footer :: footer" />
+    <attr sel="#footer" th:replace="~{footer :: footer}" />
 
-    <attr sel="nav" th:replace="navigator::nav"/>
+    <attr sel="nav" th:replace="~{navigator::nav}"/>
 
     <attr sel="#search-form" th:action="@{/articles}" th:method="get" />
     <attr sel="#search-type" th:remove="all-but-first">
@@ -55,7 +55,12 @@
         <attr sel="tbody">
             <attr sel="tr" th:each="article : ${articles}">
                 <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}"/>
-                <attr sel="td.hashtag" th:text="${article.hashtags}" />
+                <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtags}">
+                    <attr sel="a"
+                          th:text="'#' + ${hashtag}"
+                          th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+                    />
+                </attr>
                 <attr sel="td.user-id" th:text="${article.nickname}" />
                 <attr sel="td.createDate/time" th:datetime="${article.createDate}" th:text="${#temporals.format(article.createDate, 'yyyy-MM-dd')}"/>
             </attr>

--- a/fastcampus-project-board/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#header" th:replace="header :: header" />
-    <attr sel="#footer" th:replace="footer :: footer" />
+    <attr sel="#header" th:replace="~{header :: header}" />
+    <attr sel="#footer" th:replace="~{footer :: footer}" />
 
     <attr sel="main" th:object="${articles}">
         <attr sel="#hashtags" th:remove="all-but-first">


### PR DESCRIPTION
직접 입력하던 해시태그를 본문에서 파싱하여 자동으로 해시태그를 인식할 수 있도록 구현함.
더 이상 Article 테이블에서 관리하는 것이 아닌 Hashtag 테이블로 따로 관리하도록 변경됨에 따라 
관련된 서비스 로직 모두 수정했고, 뷰도 맞춰서 수정했다