### PR TITLE
[고도화] 댓글 기능 고도화 - 1차 대댓글 : 뷰 수정

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleCommentController.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleCommentController.java
@@ -5,12 +5,14 @@ import com.fastcampus.projectboard.dto.request.ArticleCommentRequest;
 import com.fastcampus.projectboard.dto.security.BoardPrincipal;
 import com.fastcampus.projectboard.service.ArticleCommentService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/comments")
 @Controller

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -4,11 +4,13 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
+@Slf4j
 @Table(indexes = {
         @Index(columnList = "content"),
         @Index(columnList = "createUser"),
@@ -56,9 +58,7 @@ public class ArticleComment extends AuditingFields{
     }
 
     public void addChildComment(ArticleComment child) {
-        //대댓글에 부모ID 세팅
         child.setParentCommentId(this.getId());
-        //부모ID가 세팅된 대댓글을 childComments에 세팅
         this.getChildComments().add(child);
     }
 

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/ArticleWithCommentsDto.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/ArticleWithCommentsDto.java
@@ -20,8 +20,8 @@ public record ArticleWithCommentsDto(
         LocalDateTime updateDate,
         String updateUser
 ) {
-    public static ArticleWithCommentsDto of(Long id, UserAccountDto userAccountDto, Set<ArticleCommentDto> articleCommentDtos, String title, String content, Set<HashtagDto> hashtagDtos, LocalDateTime createdAt, String createdBy, LocalDateTime updateDate, String updateUser) {
-        return new ArticleWithCommentsDto(id, userAccountDto, articleCommentDtos, title, content, hashtagDtos, createdAt, createdBy, updateDate, updateUser);
+    public static ArticleWithCommentsDto of(Long id, UserAccountDto userAccountDto, Set<ArticleCommentDto> articleCommentDtos, String title, String content, Set<HashtagDto> hashtagDtos, LocalDateTime createDate, String createdBy, LocalDateTime updateDate, String updateUser) {
+        return new ArticleWithCommentsDto(id, userAccountDto, articleCommentDtos, title, content, hashtagDtos, createDate, createdBy, updateDate, updateUser);
     }
 
     public static ArticleWithCommentsDto from(Article entity) {

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/UserAccountDto.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/UserAccountDto.java
@@ -20,8 +20,8 @@ public record UserAccountDto(
         return new UserAccountDto(userId, userPassword, email, nickname, memo, null, null, null, null);
     }
 
-    public static UserAccountDto of(String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createdAt, String createUser, LocalDateTime updateDate, String updateUser) {
-        return new UserAccountDto(userId, userPassword, email, nickname, memo, createdAt, createUser, updateDate, updateUser);
+    public static UserAccountDto of(String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createDate, String createUser, LocalDateTime updateDate, String updateUser) {
+        return new UserAccountDto(userId, userPassword, email, nickname, memo, createDate, createUser, updateDate, updateUser);
     }
 
     public static UserAccountDto from(UserAccount entity) {

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -49,8 +49,8 @@ public record ArticleWithCommentsResponse(
 
     private static Set<ArticleCommentResponse> organizeChildComments(Set<ArticleCommentDto> dtos) {
         Map<Long, ArticleCommentResponse> map = dtos.stream()
-                .map(ArticleCommentResponse::from)
-                .collect(Collectors.toMap(ArticleCommentResponse::id, Function.identity()));
+                        .map(ArticleCommentResponse::from)
+                        .collect(Collectors.toMap(ArticleCommentResponse::id, Function.identity()));
 
         map.values().stream()
                 .filter(ArticleCommentResponse::hasParentComment)

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleCommentService.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleCommentService.java
@@ -39,7 +39,7 @@ public class ArticleCommentService {
         try {
             //article, userAccount를 어떻게 활용할건지
             //댓글을 작성할 때
-            //TODO 대댓글 구현하고 45, 47~52 라인 지우고 다시 테스트해보기
+            //TODO 대댓글 구현하고 45, 47~52 라인 지우고 다시 테스트해보기 > 결론 : 자식 댓글로 안들어감
             Article article = articleRepository.getReferenceById(dto.articleId());
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
             ArticleComment articleComment = dto.toEntity(article, userAccount);

--- a/fastcampus-project-board/src/main/resources/data.sql
+++ b/fastcampus-project-board/src/main/resources/data.sql
@@ -571,12 +571,6 @@ Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
 
 Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.', 'Wilmer', 'Ingra', '2021-07-19 14:18:17', '2022-01-23 17:29:54')
 ;
-insert into article_comment (article_id, user_id, parent_comment_id, content, create_date, update_date, create_user, update_user) values
-(49, 'hg', 1, '퍼가요~', '2023-07-22 11:21:23', '2023-08-02 06:23:47', 'hg', 'hg')
-,(49, 'hg', 1, '퍼가요~', '2023-08-31 21:50:53', '2023-03-21 20:30:45', 'hg', 'hg')
-,(49, 'hg', 1, '퍼가요~', '2023-08-22 10:37:21', '2023-07-12 15:26:18', 'hg', 'hg')
-,(49, 'hg2', 1, '퍼가요~', '2023-07-25 05:21:19', '2023-10-07 22:24:08', 'hg2', 'hg2')
-,(49, 'hg2', 1, '퍼가요~', '2023-05-08 22:00:10', '2023-02-14 14:42:05', 'hg2', 'hg2');
 
 -- 300 댓글
 insert into article_comment (article_id, user_id, parent_comment_id, content, create_date, update_date, create_user, update_user) values
@@ -881,6 +875,13 @@ insert into article_comment (article_id, user_id, parent_comment_id, content, cr
                                                                                                                                       (56, 'hg', null, 'Sed ante. Vivamus tortor. Duis mattis egestas metus.', '2021-11-18 01:32:48', '2021-06-06 01:59:25', 'Vittorio', 'Milty'),
                                                                                                                                       (19, 'hg', null, 'In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.', '2021-05-07 23:57:29', '2021-04-03 21:55:11', 'Oliver', 'Graehme')
 ;
+
+insert into article_comment (article_id, user_id, parent_comment_id, content, create_date, update_date, create_user, update_user) values
+(49, 'hg', 1, '퍼가요~', '2023-07-22 11:21:23', '2023-08-02 06:23:47', 'hg', 'hg')
+,(49, 'hg', 1, '퍼가요~', '2023-08-31 21:50:53', '2023-03-21 20:30:45', 'hg', 'hg')
+,(49, 'hg', 1, '퍼가요~', '2023-08-22 10:37:21', '2023-07-12 15:26:18', 'hg', 'hg')
+,(49, 'hg2', 1, '퍼가요~', '2023-07-25 05:21:19', '2023-10-07 22:24:08', 'hg2', 'hg2')
+,(49, 'hg2', 1, '퍼가요~', '2023-05-08 22:00:10', '2023-02-14 14:42:05', 'hg2', 'hg2');
 
 insert into hashtag (hashtag_name, create_date, update_date, create_user, update_user) values
                                                                                          ('blue', now(), now(), 'hg', 'hg'),

--- a/fastcampus-project-board/src/main/resources/templates/articles/detail.html
+++ b/fastcampus-project-board/src/main/resources/templates/articles/detail.html
@@ -3,27 +3,32 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="Uno Kim">
     <title>게시글 페이지</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
-    <link href="/css/articles/table-header.css" rel="stylesheet">
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    <link href="/css/articles/article-content.css" rel="stylesheet">
 </head>
+
 <body>
-<header id="header"></header>
+
+<header id="header">
+    헤더 삽입부
+    <hr>
+</header>
 
 <main id="article-main" class="container">
     <header id="article-header" class="py-5 text-center">
-        <h1 id="title">첫번째 글</h1>
+        <h1>첫번째 글</h1>
     </header>
 
     <div class="row g-5">
         <section class="col-md-3 col-lg-4 order-md-last">
             <aside>
-                <p><span id="nickname" class="nick-name">HG</span></p>
-                <p><a id="id" href="mailto:chlgusrms96@naver.com">hg@mail.com</a></p>
-                <p>
-                    <time id="createDate" datetime="2023-08-21T00:00:00"></time>
-                </p>
+                <p><span id="nickname">Uno</span></p>
+                <p><a id="email" href="mailto:djkehh@gmail.com">uno@mail.com</a></p>
+                <p><time id="created-at" datetime="2022-01-01T00:00:00">2022-01-01</time></p>
                 <p><span id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></p>
             </aside>
         </section>
@@ -44,11 +49,11 @@
 
     <div class="row g-5">
         <section>
-            <form class="row g-3" id="comment-form">
+            <form class="row g-3 comment-form">
                 <input type="hidden" class="article-id">
                 <div class="col-md-9 col-lg-8">
                     <label for="comment-textbox" hidden>댓글</label>
-                    <textarea class="form-control" id="comment-textbox" placeholder="댓글 쓰기.." rows="3" required></textarea>
+                    <textarea class="form-control comment-textbox" id="comment-textbox" placeholder="댓글 쓰기.." rows="3" required></textarea>
                 </div>
                 <div class="col-md-3 col-lg-4">
                     <label for="comment-submit" hidden>댓글 쓰기</label>
@@ -57,23 +62,56 @@
             </form>
 
             <ul id="article-comments" class="row col-md-10 col-lg-8 pt-3">
-                <li>
-                    <form class="comment-form">
+                <li class="parent-comment">
+                    <form class="comment-delete-form">
                         <input type="hidden" class="article-id">
                         <div class="row">
                             <div class="col-md-10 col-lg-9">
                                 <strong>Uno</strong>
                                 <small><time>2022-01-01</time></small>
-                                <p>
+                                <p class="mb-1">
                                     Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
                                     Lorem ipsum dolor sit amet
                                 </p>
                             </div>
                             <div class="col-2 mb-3 align-self-center">
-                                <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
+                                <button type="submit" class="btn btn-outline-danger">삭제</button>
                             </div>
                         </div>
                     </form>
+
+                    <ul class="row me-0">
+                        <li class="child-comment">
+                            <form class="comment-delete-form">
+                                <input type="hidden" class="article-id">
+                                <div class="row">
+                                    <div class="col-md-10 col-lg-9">
+                                        <strong>Uno</strong>
+                                        <small><time>2022-01-01</time></small>
+                                        <p class="mb-1">
+                                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
+                                            Lorem ipsum dolor sit amet
+                                        </p>
+                                    </div>
+                                    <div class="col-2 mb-3 align-self-center">
+                                        <button type="submit" class="btn btn-outline-danger">삭제</button>
+                                    </div>
+                                </div>
+                            </form>
+                        </li>
+                    </ul>
+
+                    <div class="row">
+                        <details class="col-md-10 col-lg-9 mb-4">
+                            <summary>댓글 달기</summary>
+                            <form class="comment-form">
+                                <input type="hidden" class="article-id">
+                                <input type="hidden" class="parent-comment-id">
+                                <textarea class="form-control comment-textbox" placeholder="댓글 쓰기.." rows="2" required></textarea>
+                                <button class="form-control btn btn-primary mt-2" type="submit">쓰기</button>
+                            </form>
+                        </details>
+                    </div>
                 </li>
             </ul>
         </section>
@@ -95,11 +133,13 @@
             </ul>
         </nav>
     </div>
-
-    <footer id="footer"></footer>
 </main>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm"
-        crossorigin="anonymous"></script>
+
+<footer id="footer">
+    <hr>
+    푸터 삽입부
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/fastcampus-project-board/src/main/resources/templates/articles/detail.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/articles/detail.th.xml
@@ -24,20 +24,31 @@
 
     <attr sel="#article-content/pre" th:text="${article.content}" />
 
-    <attr sel="#article-comments">
-        <attr sel="li" th:each="articleComment : ${articleComments}">
-            <attr sel="form" th:action="'/comments/' + ${articleComment.id} + '/delete'" th:method="post">
+    <attr sel="#article-comments" th:remove="all-but-first">
+        <attr sel=".parent-comment[0]" th:each="articleComment : ${articleComments}">
+            <attr sel=".comment-delete-form" th:action="'/comments/' + ${articleComment.id} + '/delete'" th:method="post">
                 <attr sel="div/strong" th:text="${articleComment.nickname}" />
                 <attr sel="div/small/time" th:datetime="${articleComment.createDate}" th:text="${#temporals.format(articleComment.createDate, 'yyyy-MM-dd HH:mm:ss')}" />
                 <attr sel="div/p" th:text="${articleComment.content}" />
                 <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
             </attr>
         </attr>
+        <attr sel="ul" th:if="${!articleComment.childComments.isEmpty()}" th:remove="all-but-first">
+            <attr sel=".child-comment[0]" th:each="childComment : ${articleComment.childComments}">
+                <attr sel=".comment-delete-form" th:action="'/comments/' + ${childComment.id} + '/delete'" th:method="post">
+                    <attr sel="div/strong" th:text="${childComment.nickname}" />
+                    <attr sel="div/small/time" th:datetime="${childComment.createDate}" th:text="${#temporals.format(childComment.createDate, 'yyyy-MM-dd HH:mm:ss')}" />
+                    <attr sel="div/p" th:text="${childComment.content}" />
+                    <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${childComment.userId} == ${#authentication.name}" />
+                </attr>
+            </attr>
+        </attr>
+        <attr sel=".parent-comment-id" th:name="parentCommentId" th:value="${articleComment.id}" />
     </attr>
 
     <attr sel=".article-id" th:name="articleId" th:value="${article.id}" />
-    <attr sel="#comment-form" th:action="@{/comments/new}" th:method="post">
-        <attr sel="#comment-textbox" th:name="content" />
+    <attr sel=".comment-form" th:action="@{/comments/new}" th:method="post">
+        <attr sel=".comment-textbox" th:name="content" />
     </attr>
 
     <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and ${article.userId} == ${#authentication.name}">


### PR DESCRIPTION
대댓글 도메인 안에서 부모, 자식 관계를 설정하는 코드를 추가
자식 댓글의 컬렉션 변화가 쿼리에 반영되게끔
cascading 규칙을 모두 적용
이번엔 단방향 연관관계 설정을 사용해보기로 함
따라서 부모 댓글은 엔티티가 아닌 Long id를 직접 표현

또한 자식 댓글을 추가할 수 있는 메소드 추가 제공