### PR TITLE
[고도화] 보안 기능 고도화 - 환경변수의 사용

### DIFF
--- a/fastcampus-project-board/src/main/resources/application.yaml
+++ b/fastcampus-project-board/src/main/resources/application.yaml
@@ -9,9 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/board
-    username: postgres
-    password: 102501
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
 #    driver-class-name:  > postgresql Driver를 외울 필요 없이 url을 참조하여 자동으로 설정된다고 함.
 
 #    mysql정보 > postgresql로 마이그레이션 됨에 따라 주석처리


### PR DESCRIPTION
이 pr은 application.yaml에 노출되어 있던 각종 민감정보를 변수로 치환하여 보안을 신경쓰도록 한다.
그러나 사실 이미 변경 전 이력이 해당 저장소에 남아 있기 때문에 여전히 노출된 값을 찾아 볼 수 있다.
근본적인 해결을 하려면 이 저장소를 통째로 지우고 새로 올리는 수 밖에 없다고 함.

This closes #65 