### PR TITLE
[고도화] Swagger UI로 API 문서화하기

### DIFF
--- a/fastcampus-project-board/build.gradle
+++ b/fastcampus-project-board/build.gradle
@@ -49,6 +49,17 @@ dependencies {
     // @ConfigurationProperties를 사용하기 위한 의존성
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    // swagger ui 의존성 추가
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.hibernate.validator:hibernate-validator:7.0.1.Final'
+    implementation 'org.hibernate.validator:hibernate-validator-cdi:7.0.1.Final'
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.1'
+    implementation 'org.glassfish:jakarta.el:5.0.0-M1'
+
+    // swagger-ui 주석 읽기
+    implementation 'com.github.therapi:therapi-runtime-javadoc:0.15.0'
+    annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
+
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")


### PR DESCRIPTION
간단한 의존성 추가만으로 즉시 스웨거 문서화가 진행됨.
처음에 springdoc에서 제시하는 의존성만 추가했을 땐 jakarta validation 관련 에러가 계속 발생했는데, 몇 가지 의존성을 더 추가해주니 에러가 잡혔음.